### PR TITLE
Add missing includes

### DIFF
--- a/HideImport.hpp
+++ b/HideImport.hpp
@@ -2,6 +2,8 @@
 
 #include "xdl/include/xdl.h"
 #include <elf.h>
+#include <cstring>
+#include <link.h>
 #include <mutex>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
## Summary
- include cstring and link.h in HideImport.hpp

## Testing
- `g++ -std=c++17 -c test.cpp` *(fails: `ELF_ST_TYPE` was not declared)*