### PR TITLE
Remove unused includes

### DIFF
--- a/HideImport.hpp
+++ b/HideImport.hpp
@@ -5,8 +5,11 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <type_traits>
-#include <stdexcept>
+#include <cstring>
+
+#ifndef ELF_ST_TYPE
+#define ELF_ST_TYPE ELF64_ST_TYPE
+#endif
 
 namespace HideImport {
     static std::unordered_map<std::string, void*> gHandleCache;


### PR DESCRIPTION
## Summary
- remove `<type_traits>` and `<stdexcept>` from `HideImport.hpp`
- include `<cstring>` and define `ELF_ST_TYPE` fallback

## Testing
- `g++ -std=c++17 -I. -Ixdl/include -c Main.cpp`